### PR TITLE
windows validate

### DIFF
--- a/.github/ci-windows-recheck.txt
+++ b/.github/ci-windows-recheck.txt
@@ -1,1 +1,2 @@
 trigger windows CI
+poke 2025-08-12T15:02:25Z

--- a/.github/ci-windows-recheck.txt
+++ b/.github/ci-windows-recheck.txt
@@ -1,0 +1,1 @@
+trigger windows CI

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -61,8 +61,8 @@ jobs:
       env:
         DATABASE_URL: postgresql://test:test@localhost:5432/kmp_supply_chain_test
       run: |
-        npx -y drizzle-kit generate:pg
-        npx -y drizzle-kit push:pg
+        npx -y drizzle-kit generate
+        npx -y drizzle-kit push
 
     - name: 🔧 Build project
       working-directory: message_bus
@@ -113,8 +113,8 @@ jobs:
       env:
         DATABASE_URL: postgresql://test:test@localhost:5432/kmp_supply_chain_test
       run: |
-        npx -y drizzle-kit generate:pg
-        npx -y drizzle-kit push:pg
+        npx -y drizzle-kit generate
+        npx -y drizzle-kit push
 
     - name: 🚀 Start test server
       working-directory: message_bus
@@ -183,8 +183,8 @@ jobs:
       env:
         DATABASE_URL: postgresql://test:test@localhost:5432/kmp_supply_chain_test
       run: |
-        npx -y drizzle-kit generate:pg
-        npx -y drizzle-kit push:pg
+        npx -y drizzle-kit generate
+        npx -y drizzle-kit push
 
     - name: 🚀 Start test server
       working-directory: message_bus
@@ -255,8 +255,8 @@ jobs:
       env:
         DATABASE_URL: postgresql://test:test@localhost:5432/kmp_supply_chain_test
       run: |
-        npx -y drizzle-kit generate:pg
-        npx -y drizzle-kit push:pg
+        npx -y drizzle-kit generate
+        npx -y drizzle-kit push
 
     - name: 🚀 Start test server
       working-directory: message_bus

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -61,8 +61,8 @@ jobs:
       env:
         DATABASE_URL: postgresql://test:test@localhost:5432/kmp_supply_chain_test
       run: |
-        npm run db:generate
-        npm run db:push
+        npx -y drizzle-kit generate:pg
+        npx -y drizzle-kit push:pg
 
     - name: 🔧 Build project
       working-directory: message_bus
@@ -113,8 +113,8 @@ jobs:
       env:
         DATABASE_URL: postgresql://test:test@localhost:5432/kmp_supply_chain_test
       run: |
-        npm run db:generate
-        npm run db:push
+        npx -y drizzle-kit generate:pg
+        npx -y drizzle-kit push:pg
 
     - name: 🚀 Start test server
       working-directory: message_bus
@@ -183,8 +183,8 @@ jobs:
       env:
         DATABASE_URL: postgresql://test:test@localhost:5432/kmp_supply_chain_test
       run: |
-        npm run db:generate
-        npm run db:push
+        npx -y drizzle-kit generate:pg
+        npx -y drizzle-kit push:pg
 
     - name: 🚀 Start test server
       working-directory: message_bus
@@ -255,8 +255,8 @@ jobs:
       env:
         DATABASE_URL: postgresql://test:test@localhost:5432/kmp_supply_chain_test
       run: |
-        npm run db:generate
-        npm run db:push
+        npx -y drizzle-kit generate:pg
+        npx -y drizzle-kit push:pg
 
     - name: 🚀 Start test server
       working-directory: message_bus

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - 'v*'
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,14 +123,21 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: brew install gnupg
 
-      - name: Install GPG (Windows)
-        if: ${{ runner.os == 'Windows' }}
-        shell: pwsh
-        run: |
-          choco install gnupg -y
-          $gpgPath = "C:\\Program Files\\GnuPG\\bin"
-          if (Test-Path $gpgPath) { $env:PATH = "$env:PATH;$gpgPath" }
-
+        - name: Install GPG (Windows)
+          if: ${{ runner.os == 'Windows' }}
+          shell: pwsh
+          run: |
+            $ErrorActionPreference = 'Stop'
+            $ProgressPreference = 'SilentlyContinue'
+            if (Get-Command winget -ErrorAction SilentlyContinue) {
+              winget install --id GnuPG.GnuPG --silent --accept-package-agreements --accept-source-agreements
+            } else {
+              choco install gnupg --yes --no-progress --execution-timeout=5400
+            }
+            Get-Process -Name 'gnupg-w32*' -ErrorAction SilentlyContinue | Stop-Process -Force
+            $gpgPath = 'C:\Program Files\GnuPG\bin'
+            if (Test-Path $gpgPath) { $env:PATH = "$env:PATH;$gpgPath" }
+            gpg --version
       - name: Check if GPG secret present
         id: gpgcheck
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,12 +129,31 @@ jobs:
           run: |
             $ErrorActionPreference = 'Stop'
             $ProgressPreference = 'SilentlyContinue'
-            if (Get-Command winget -ErrorAction SilentlyContinue) {
-              winget install --id GnuPG.GnuPG --silent --accept-package-agreements --accept-source-agreements
-            } else {
-              choco install gnupg --yes --no-progress --execution-timeout=5400
-            }
+            # Stop any orphaned installers before starting
             Get-Process -Name 'gnupg-w32*' -ErrorAction SilentlyContinue | Stop-Process -Force
+        
+            function Invoke-With-Retry {
+              param([scriptblock]$Script, [int]$Retries = 3, [int]$DelaySeconds = 15)
+              for ($i = 1; $i -le $Retries; $i++) {
+                try {
+                  & $Script
+                  if ($LASTEXITCODE -ne $null -and $LASTEXITCODE -ne 0) { throw "Command failed with exit code $LASTEXITCODE" }
+                  return
+                } catch {
+                  if ($i -eq $Retries) { throw }
+                  Write-Warning ("Attempt $i failed: $($_.Exception.Message). Retrying in ${DelaySeconds}s...")
+                  Get-Process -Name 'gnupg-w32*' -ErrorAction SilentlyContinue | Stop-Process -Force
+                  Start-Sleep -Seconds $DelaySeconds
+                }
+              }
+            }
+        
+            if (Get-Command winget -ErrorAction SilentlyContinue) {
+              Invoke-With-Retry { winget install --id GnuPG.GnuPG --silent --accept-package-agreements --accept-source-agreements }
+            } else {
+              Invoke-With-Retry { choco install gnupg --yes --no-progress --execution-timeout=5400 }
+            }
+        
             $gpgPath = 'C:\Program Files\GnuPG\bin'
             if (Test-Path $gpgPath) { $env:PATH = "$env:PATH;$gpgPath" }
             gpg --version


### PR DESCRIPTION
- **ci: fix Windows GPG install using winget with Chocolatey fallback and safer flags**
- **ci: add retry wrapper to Windows GPG install and cleanup between attempts**
- **ci: use npx drizzle-kit for DB setup to avoid missing CLI**
- **ci: use modern drizzle-kit commands (generate, push) across CI**
- **chore(ci): trigger release workflow to validate Windows**
